### PR TITLE
Fix missing Python 3.6 Linux build

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   script: python setup.py install --single-version-externally-managed --record record.txt
 
 requirements:


### PR DESCRIPTION
Currently, the Linux build for Python 3.6 is missing for some reason. It looks like the Circle CI didn't start for Python 3.6.   

Opening this PR to see if it would be triggered for a new PR. 

Waiting for some feedback before merging.  cf https://github.com/conda-forge/staged-recipes/pull/4808 for more context of feedstock creation in case it's useful.

cc @dougalsutherland 

**Edit:** nope, PY 3.6 CircleCI build still not triggered.