### PR TITLE
use scipy versions that are actually available

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,15 +25,17 @@ requirements:
     - numpy 1.10.*  # [not (win and py36)]
     - numpy 1.11.*  # [win and py36]
     # implicit cimports BLAS from scipy
-    - scipy 0.16.*  # [not (win and py36)]
-    - scipy 0.18.*  # [win and py36]
+    - scipy 0.16.*  # [win and py<36]
+    - scipy 0.17.*  # [unix and py<36]
+    - scipy 0.18.*  # [py36]
   run:
     - python
     - libgcc  # [unix]
     - numpy >=1.10  # [not (win and py36)]
     - numpy >=1.11  # [win and py36]
-    - scipy >=0.16  # [not (win and py36)]
-    - scipy >=0.18  # [win and py36]
+    - scipy >=0.16  # [win and py<36]
+    - scipy >=0.17  # [unix and py<36]
+    - scipy >=0.18  # [py36]
 
 test:
   imports:


### PR DESCRIPTION
So, I'm pretty confused about this; local re-renderings won't add a python 3.6 build even though `conda build recipe --python=3.6` goes through just fine. So let's see if this helps for some reason:

@conda-forge-admin, please rerender.