### PR TITLE
Add a fortran compiler as a dependency

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,6 +45,7 @@ outputs:
       build:
         - {{ compiler('c') }}
         - {{ compiler('cxx') }}
+        - {{ compiler('fortran') }}
         - {{ compiler('cuda') }}  # [linux64 and cuda_compiler_version != "None"]
         - make  # [linux64]
       host:


### PR DESCRIPTION
The build script ends up pip installing a number of packages
such as scipy. Typically these packages will be installed via
pre-compiled wheels, but if a wheel is not available they
will be compiled from source. This process is opaque to conda
so it doesn't help with installing the dependencies, so we have
to list them explicitly. In this case, building scipy requires
a fortran compiler.

This is particularly important for building for Pyston because
there are currently no pre-compiled wheels available in pypi.