### PR TITLE
Remove pin_compatabile for numpy/scipy

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,7 +2,7 @@
 {% set name = "implicit" %}
 {% set version = "0.7.0" %}
 {% set sha256 = "e7bcf0c267404f0e579f268515174e981996bb268106c5be869d312bf48ab72e" %}
-{% set number = "6" %}
+{% set number = "7" %}
 
 {% set implicit_proc_type = "cpu" if (cuda_compiler|default("None")) == "None" else "gpu" %}
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -64,8 +64,8 @@ outputs:
         - libcurand-dev      # [(cuda_compiler_version or "").startswith("12")]
       run:
         - python
-        - {{ pin_compatible('numpy') }}
-        - {{ pin_compatible('scipy') }}
+        - numpy
+        - scipy >=0.16
         - tqdm >=4.27
       run_constrained:
         - implicit-proc * {{ implicit_proc_type }}


### PR DESCRIPTION
This seems to cause overspecifying the numpy/scipy versions required https://github.com/benfred/implicit/issues/679

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
